### PR TITLE
fix: update pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx lerna run --parallel precommit
+npx lerna run precommit


### PR DESCRIPTION
Running lint-staged in parallel on each packages causes a bug which stashes all of the staged changes. This can be confusing for the developers, removing the --parallel flag fixes the problem.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Running lint-staged in parallel on each packages causes a bug which stashes all of the staged changes. This can be confusing for the developers, removing the --parallel flag fixes the problem.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Lint-Staged no longer stashes the staged files, this helps to get rid of the confusion about the changes done that might seem lost.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested locally over a significant amount of time. 
The initial issue is intermittent,  but is reproducible around 1/10-1/20 times. After removing the parallel flag it has no longer been reproduced in more than 100+ attempts. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
