### PR TITLE
fix: return type must be list of products

### DIFF
--- a/packages/composables/src/useProduct/index.ts
+++ b/packages/composables/src/useProduct/index.ts
@@ -8,13 +8,13 @@ import type {
   UseProductSearchParams as SearchParams
 } from '../types';
 
-const params: UseProductFactoryParams<Product, SearchParams> = {
+const params: UseProductFactoryParams<Product[], SearchParams> = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   productsSearch: async (context: Context, params) => {
     console.log('Mocked: useProduct.productsSearch');
 
-    return {};
+    return [];
   }
 };
 
-export const useProduct = useProductFactory<Product, SearchParams>(params);
+export const useProduct = useProductFactory<Product[], SearchParams>(params);


### PR DESCRIPTION
## Description
I got some errors compiling my extended vsf test project and finally found out that this type is not correct and must be something like a product list. In https://github.com/vuestorefront/vue-storefront/blob/main/packages/core/src/factories/useProductFactory.ts PRODUCTS is expected here.

## Related Issue
My derived project could not be compiled.
```
Type '(context: Context<any, any, any>, params: ProductsSearchParams & { customQuery?: CustomQuery; }) => Promise<Product[]>' is not assignable to type '(context: Context<any, any, any>, params: ProductsSearchParams & { customQuery?: CustomQuery; }) => Promise<Product>'.
```

## Motivation and Context
This makes it easier for newbies like me.

## How Has This Been Tested?
My derived project could be compiled after this fix.

## Screenshots (if appropriate):
n/a

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
